### PR TITLE
[Navbar/Mobile Menu Bug Fix] Disabled mobile menu and enabled navbar on small horizontal screens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,22 @@
 {
-  "extends": ["next", "next/core-web-vitals", "plugin:jsx-a11y/recommended", "plugin:prettier/recommended"],
-  "overrides": [{
-    "files": [
-      "*.ts",
-      "*.tsx"
-    ],
-    "rules": {
-      "jsx-a11y/anchor-is-valid": "off"
+  "extends": [
+    "next",
+    "next/core-web-vitals",
+    "plugin:jsx-a11y/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "jsx-a11y/anchor-is-valid": "off",
+        "prettier/prettier": [
+          "error",
+          {
+            "endOfLine": "auto"
+          }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/components/MobileMenu/index.tsx
+++ b/components/MobileMenu/index.tsx
@@ -22,7 +22,7 @@ const MobileMenu = ({ links }: MobileMenu) => {
             leaveTo='transform scale-95 opacity-0 translate-y-10'
           >
             <Popover.Panel className='flex flex-col items-end justify-end h-screen'>
-              <div className='bg-primary flex justify-around flex-col items-center p-3 rounded-lg w-full h-[50%] font-serif'>
+              <div className='bg-primary flex justify-around flex-col items-center p-3 rounded-lg w-full h-1/2 font-serif'>
                 {links.map(navItem => (
                   <Link key={navItem.page} href={navItem.route}>
                     <a className='px-2 w-full opacity-100 transition-all duration-150 focus:ring focus:ring-teal focus:ring-opacity-50 rounded'>

--- a/components/MobileMenu/index.tsx
+++ b/components/MobileMenu/index.tsx
@@ -41,7 +41,7 @@ const MobileMenu = ({ links }: MobileMenu) => {
           </Transition>
           <Popover.Button
             className={
-              'flex items-center justify-center md:hidden w-10 h-10 rounded-full m-2 no-tap-highlight ' +
+              'flex items-center justify-center sm:hidden w-10 h-10 rounded-full m-2 no-tap-highlight ' +
               (open ? 'bg-teal text-black' : 'bg-primary')
             }
           >

--- a/components/MobileMenu/index.tsx
+++ b/components/MobileMenu/index.tsx
@@ -21,8 +21,8 @@ const MobileMenu = ({ links }: MobileMenu) => {
             leaveFrom='transform scale-100 opacity-100 translate-y-0'
             leaveTo='transform scale-95 opacity-0 translate-y-10'
           >
-            <Popover.Panel className='flex flex-col items-end'>
-              <div className='bg-primary flex justify-around flex-col items-center p-3 rounded-lg w-full h-96 font-serif'>
+            <Popover.Panel className='flex flex-col items-end justify-end h-screen'>
+              <div className='bg-primary flex justify-around flex-col items-center p-3 rounded-lg w-full h-[50%] font-serif'>
                 {links.map(navItem => (
                   <Link key={navItem.page} href={navItem.route}>
                     <a className='px-2 w-full opacity-100 transition-all duration-150 focus:ring focus:ring-teal focus:ring-opacity-50 rounded'>

--- a/components/NavBar/index.tsx
+++ b/components/NavBar/index.tsx
@@ -19,7 +19,7 @@ const Navbar = ({ links }: NavbarProps) => {
   }, [])
 
   return (
-    <header className='fixed inset-x-0 top-0 z-10 hidden py-2 bg-primary md:block'>
+    <header className='fixed inset-x-0 top-0 z-10 hidden py-2 bg-primary sm:block'>
       <nav className='font-serif text-2xl text-white container flex justify-between px-3 mx-auto'>
         <Link href='/'>
           <a className='flex relative hover:opacity-75 focus:outline-none focus:ring focus:ring-teal focus: focus:ring-opacity-50 rounded'>


### PR DESCRIPTION
- The mobile menu was overflowing on small devices when in horizontal view.
- Fixed by hiding the mobile menu for horizontal screens (sm+) and showing the navbar instead.

Before:
![image](https://user-images.githubusercontent.com/22740095/150735636-d3350691-ac75-4878-a1ba-4d8e1b28d58a.png)

After:
![image](https://user-images.githubusercontent.com/22740095/150735519-e5770649-0053-4938-bf4d-5be5c3139bf4.png)
