### PR TITLE
Fixed "all-steps" recipe page styling and made opacity of the slideshow arrows lower

### DIFF
--- a/components/Custom/Carousel/index.tsx
+++ b/components/Custom/Carousel/index.tsx
@@ -74,12 +74,12 @@ const Carousel = ({
         <>
           <Arrow
             direction='left'
-            className='w-12 h-12 absolute bg-opacity-50 p-1.5 top-1/2 rounded m-1 bg-grey transform -translate-y-1/2 left-0'
+            className='w-12 h-12 absolute bg-opacity-50 p-1.5 top-1/2 rounded m-1 bg-grey/30 transform -translate-y-1/2 left-0'
             onClick={() => slider.current?.prev()}
           />
           <Arrow
             direction='right'
-            className='w-12 h-12 absolute bg-opacity-50 top-1/2 p-1.5 rounded m-1 bg-grey transform -translate-y-1/2 right-0'
+            className='w-12 h-12 absolute bg-opacity-50 top-1/2 p-1.5 rounded m-1 bg-grey/30 transform -translate-y-1/2 right-0'
             onClick={() => slider.current?.next()}
           />
         </>

--- a/pages/recipes/[slug]/all-steps.tsx
+++ b/pages/recipes/[slug]/all-steps.tsx
@@ -31,7 +31,7 @@ const RecipeSteps = ({ recipe }: RecipeStepsProps) => {
   } else {
     const colorScheme = recipe.colorScheme
     return (
-      <div className={`${colorScheme?.bg} p-10`}>
+      <div className={`${colorScheme?.bg} px-10 py-10 md:pt-20`}>
         <h1
           className={`${colorScheme?.header} text-4xl underline font-semibold font-serif`}
         >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22740095/154792234-71669ac2-1fc0-463c-8557-b9007166d5fb.png)

- Adding top padding to the all-steps page
- Reduced opacity of control arrows in the slideshow