### PR TITLE
[FIX] Fixed some typos in route names.

### DIFF
--- a/components/Map/assets/locations.ts
+++ b/components/Map/assets/locations.ts
@@ -136,11 +136,11 @@ const locations = [
     headerColor: 'primary',
     headerText: 'Clucky Coop',
     captionText:
-      "The Clucky Coup keeps all the chickens safe and keeps them well away from the busy road. Strutting around the Clucky Coup, the Cheeky Chicken loves to play with his friends when they aren't busy laying lots of lovely eggs.",
+      "The Clucky Coop keeps all the chickens safe and keeps them well away from the busy road. Strutting around the Clucky Coop, the Cheeky Chicken loves to play with his friends when they aren't busy laying lots of lovely eggs.",
     showButton: true,
     maxWidth: '',
     maxHeight: '',
-    route: 'clucky-cloop'
+    route: 'clucky-coop'
   },
   {
     id: 'yoghurtMountains',
@@ -162,7 +162,7 @@ const locations = [
     showButton: true,
     maxWidth: '',
     maxHeight: '',
-    route: 'aqua-oceans'
+    route: 'aqua-ocean'
   }
 ]
 

--- a/components/TownBox/index.tsx
+++ b/components/TownBox/index.tsx
@@ -48,7 +48,12 @@ const Townbox = ({
         </button>
 
         {showButton && (
-          <Link href={`town/${linksrc}`} passHref>
+          <Link
+            href={
+              linksrc == 'healthy-town' ? `fun-food-sort` : `town/${linksrc}`
+            }
+            passHref
+          >
             <Button className='skew-x-12' color='primary'>
               Visit
             </Button>


### PR DESCRIPTION

## Change Summary

- Fixed typos in some routes so that the location page renders correctly.

- To-do: Get assets for Zombie wasteland and Wicked Waterway