### PR TITLE
[Feature] Spinning loader component

### DIFF
--- a/components/Character/CarouselItem/index.tsx
+++ b/components/Character/CarouselItem/index.tsx
@@ -22,6 +22,7 @@ const CarouselItem = ({ chr }: CarouselItemProps): JSX.Element => {
               layout='fill'
               objectFit='contain'
               alt='Picture of the author'
+              priority={true}
             ></Image>
           </div>
         )}

--- a/components/Custom/LoadingSpinner/index.tsx
+++ b/components/Custom/LoadingSpinner/index.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+
+const LoadingSpinner = () => {
+  const router = useRouter()
+  const [isloading, setIsLoading] = useState(false)
+
+  /** Mechanism to check if the route is changing (i.e. user is trying to go to a different page) and setting isLoading state to true/false. */
+  useEffect(() => {
+    const toggleLoading = () => {
+      setIsLoading(prev => !prev)
+    }
+    router.events.on('routeChangeStart', toggleLoading)
+    router.events.on('routeChangeComplete', toggleLoading)
+
+    return () => {
+      router.events.off('routeChangeStart', toggleLoading)
+      router.events.off('routeChangeComplete', toggleLoading)
+    }
+  }, [router])
+  return (
+    <>
+      {isloading && (
+        <div className='fixed bottom-0 left-0 sm:left-auto sm:right-0 z-40 m-10 lg:m-20 w-12 h-12 border-4 border-t-transparent border-white border-solid rounded-full animate-spin '></div>
+      )}
+    </>
+  )
+}
+
+export default LoadingSpinner

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ module.exports = withPlugins(
       {
         pwa: {
           dest: 'public',
+          disable: process.env.NODE_ENV === 'production' ? false : true,
           register: true,
           skipWaiting: true
         }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app'
 
+import LoadingSpinner from '@components/Custom/LoadingSpinner'
 import { FirebaseProvider } from '@components/FirebaseContext'
 import MobileMenu from '@components/MobileMenu'
 import Navbar from '@components/NavBar'
@@ -38,6 +39,7 @@ const FoodBank = ({ Component, pageProps }: AppProps) => {
       <main className='relative min-h-screen lg:main'>
         <Component {...pageProps} />
       </main>
+      <LoadingSpinner />
     </FirebaseProvider>
   )
 }


### PR DESCRIPTION
## Change Summary
When ever user navigates to a new route, this spinning loader will appear at the bottom corner.
Ipad air:
![image](https://user-images.githubusercontent.com/22740095/155061557-79e3aa2a-cbd0-4f4f-8bf8-0fb6e85c9281.png)

Iphone xr:
![image](https://user-images.githubusercontent.com/22740095/155061602-8c4f9685-7867-4a61-9ca5-08678202be11.png)


### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
- The loader isn't visible on white backgrounds. But white loader works great on all the other backgrounds. I think we should get non-white coloured backgrounds for the white background pages.